### PR TITLE
docs: update README with missing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ This repository contains a collection of small Python scripts, tutorials, and mi
 - **IMDB_movie_revies_text_classification**: Text classification models for IMDB movie reviews, including hyperparameter tuning with Optuna. Note: The directory name contains a typo (“revies” instead of “reviews”) and is kept as-is for compatibility.
 - **WordFinder**: Utility to check if words exist in an English dictionary using the NLTK corpus.
 - **applied_FEA**: Scripts and exercises related to Applied Finite Element Analysis (FEA).
+- **charactes_mie438**: A Tkinter-based GUI tool for generating 8x16 pixel characters for SSD1306 OLED displays. Note: The directory name contains a typo (“charactes” instead of “characters”) and is kept as-is for compatibility.
 - **cifar-10_image_classification**: Image classification on the CIFAR-10 dataset using deep learning.
 - **course_scraper**: Web scraper for the ETH Zurich course catalog (VVZ) with a feature to convert JSON output to PDF.
 - **energy_levels_3d_inf_sq_well**: Physics simulation calculating energy levels, combinations, and degeneracies for a particle in a 3D infinite square well.
 - **fluid_sim_python**: Fluid dynamics simulation implementations for both CPU and GPU.
 - **foehndiagram_scrape**: A Scrapy project designed to scrape foehn wind diagrams.
+- **intro_to_FEA**: Introductory scripts and exercises for Finite Element Analysis (FEA), including symbolic computations using SymPy.
 - **kite_weather_digest**: Script to scrape kite surfing weather data (e.g., Windguru) and generate a digest.
 - **manim**: Example animation scenes using the Manim library.
 - **memo_fib**: A simple implementation of the Fibonacci sequence using memoization to optimize recursive calls.


### PR DESCRIPTION
This pull request updates the `README.md` to include documented descriptions for two subprojects that were missing from the project inventory:
- `charactes_mie438`: A Tkinter-based character generator.
- `intro_to_FEA`: Introductory scripts for Finite Element Analysis using SymPy.

The descriptions adhere to the existing format and alphabetical ordering of the documentation.

---
*PR created automatically by Jules for task [13924338520551193950](https://jules.google.com/task/13924338520551193950) started by @kubaniak*